### PR TITLE
Correção de dupla geração de hash ao cadastrar novo usuário

### DIFF
--- a/admin-users.php
+++ b/admin-users.php
@@ -154,7 +154,7 @@ $app->post("/admin/users/create", function() {
 
 	$_POST["inadmin"] = (isset($_POST["inadmin"]))?1:0;
 
-	$_POST['despassword'] = User::getPassswordHash($_POST['despassword']);
+	$_POST['despassword'] = User::getPasswordHash($_POST['despassword']);
 
 	$user->setData($_POST);
 

--- a/vendor/hcodebr/php-classes/src/Model/User.php
+++ b/vendor/hcodebr/php-classes/src/Model/User.php
@@ -138,7 +138,7 @@ class User extends Model {
 		$results = $sql->select("CALL sp_users_save(:desperson, :deslogin, :despassword, :desemail, :nrphone, :inadmin)", array(
 			":desperson"=>utf8_decode($this->getdesperson()),
 			":deslogin"=>$this->getdeslogin(),
-			":despassword"=>User::getPasswordHash($this->getdespassword()),
+			":despassword"=>$this->getdespassword(),
 			":desemail"=>$this->getdesemail(),
 			":nrphone"=>$this->getnrphone(),
 			":inadmin"=>$this->getinadmin()


### PR DESCRIPTION
O método que gera hash da senha do usuário era chamado duas vezes ao cadastrar um novo usuário. Fazia com que fosse gerado um "hash da hash", tornando a senha do usuário inválida. Notei esse problema quando cadastrei um usuário novo e tentei fazer login com ele.
Aproveitei e corrigi um typo no admin-users.php, que por coincidência é em uma das chamadas duplicadas do método.
Estou fazendo esse pull request pois algum aluno pode clonar o repo, encontrar esse bug e não saber o que fazer.